### PR TITLE
New uniqueparents

### DIFF
--- a/simulation.cpp
+++ b/simulation.cpp
@@ -50,6 +50,7 @@ int main(int argc, char** argv)
         ("bpMutStrength", po::value<double>()->default_value(0.005), "Standard deviation of the mutation model for bequeathal probability")
         ("popSize", po::value<int>()->default_value(100), "Number of individuals in the population")
         ("endpointsensitivity", po::value<double>()->default_value(0.02), "How close body size has to get to target value")
+        ("outputfrequency", po::value<int>()->default_value(50), "How often (in terms of generations) to print out data")
         ("reps", po::value<int>()->default_value(1), "Number of simulation repetitions")
         ("gen_limit", po::value<int>()->default_value(30000), "Maximum number of generations before cutting the simulation short")
         ("burnin", po::value<bool>()->default_value(true), "Should the simulation generate some initial variation first?")
@@ -80,6 +81,7 @@ int main(int argc, char** argv)
     const double beqProbStDev = vm["bpMutStrength"].as<double>();
     const int popSize = vm["popSize"].as<int>();
     const double endpointsensitivity = vm["endpointsensitivity"].as<double>();
+    const int outputFrequency = vm["outputfrequency"].as<int>();
     const int reps = vm["reps"].as<int>();
     const int gen_limit = vm["gen_limit"].as<int>();
     const bool burnin = vm["burnin"].as<bool>();
@@ -146,9 +148,6 @@ int main(int argc, char** argv)
         // Create a population of specified size, with all individuals initialized as shelter-less
         Individual squirrel(startingPhenotype);
         std::vector<Individual> Pop(popSize, squirrel);
-        
-        // How often (in terms of generations) to print out data
-        int outputFrequency = 50;
         
         // Get the absolute number of shelters available to the population
         int nShelters = ceil(shelterFraction * popSize);

--- a/simulation.cpp
+++ b/simulation.cpp
@@ -238,17 +238,14 @@ int main(int argc, char** argv)
              * and will include it in the file.
              */
             int printcount = (burnin ? count + 1 : count);
-            
-            if(!finished && printcount % outputFrequency == 0) {
-                string data = getData(Pop, target_lb, selection_strength);
-                genFile << printcount << "\t" << data;
-            }
 
             // Checking if the population has finished evolving
             if( fabs( exp(getTraitMean(Pop, "bodySize")) - exp(target_lb) ) > endpointsensitivity ) {
                 
                 if (printcount % outputFrequency == 0) {
 		   
+                    string data = getData(Pop, target_lb, selection_strength);
+                    genFile << printcount << "\t" << data;
                     evolvePop(Pop, target_lb, selection_strength, min_lb, max_lb, popSize, mutList, nShelters, calamityFrequency, calamityStrength, true, true, true, &uniqueParents);
                     genFile << uniqueParents << endl;
                     cout << "generation: " << printcount;

--- a/simulation.cpp
+++ b/simulation.cpp
@@ -42,15 +42,12 @@ string getData(std::vector<Individual> &population, double target, double selStr
 int main(int argc, char** argv)
 {
     
-    // Standard deviation of log body size
-    const double bodySizeStDev = 0.001;
-    // Standard deviation of bequeathal probability
-    const double beqProbStDev = 0.005;
-    
     po::options_description desc("Simulate trait evolution under wealth inheritance");
     desc.add_options()
         ("help", "Show help message")
         ("mutCount", po::value<int>()->default_value(1000), "Number of mutations we will have")
+        ("lbMutStrength", po::value<double>()->default_value(0.0005), "Standard deviation of the mutation model for log body size")
+        ("bpMutStrength", po::value<double>()->default_value(0.005), "Standard deviation of the mutation model for bequeathal probability")
         ("popSize", po::value<int>()->default_value(100), "Number of individuals in the population")
         ("endpointsensitivity", po::value<double>()->default_value(0.02), "How close body size has to get to target value")
         ("reps", po::value<int>()->default_value(1), "Number of simulation repetitions")
@@ -79,6 +76,8 @@ int main(int argc, char** argv)
     po::store(po::command_line_parser(argc, argv).options(desc).run(), vm);
     po::notify(vm);
     const int mutCount = vm["mutCount"].as<int>();
+    const double bodySizeStDev = vm["lbMutStrength"].as<double>();
+    const double beqProbStDev = vm["bpMutStrength"].as<double>();
     const int popSize = vm["popSize"].as<int>();
     const double endpointsensitivity = vm["endpointsensitivity"].as<double>();
     const int reps = vm["reps"].as<int>();

--- a/simulation.cpp
+++ b/simulation.cpp
@@ -152,9 +152,7 @@ int main(int argc, char** argv)
         /* Burn in the populations (optional). The burnin phase will end when the average log body
          * size gets acceptably close to the specified starting value.
          */
-         int uniqueParents;
-         int parentA;
-         int parentB;
+        int uniqueParents;
 
         if (burnin) {
             int burnCount = 0;
@@ -323,7 +321,8 @@ double variance(std::vector<double> vals, double mean) {
 
 std::vector<std::vector<double> > getMutList(int mutCount, const double lbStDev, const double bpStDev) {
     
-    std::random_device randomnessSource;
+    std::random_device lbRandomnessSource;
+    std::random_device bpRandomnessSource;
     // Define univariate normal distributions
     std::normal_distribution<double> lbMutMaker(0.0, lbStDev);
     std::normal_distribution<double> bpMutMaker(0.0, bpStDev);
@@ -332,9 +331,10 @@ std::vector<std::vector<double> > getMutList(int mutCount, const double lbStDev,
     // Store draws from the normal distributions specified above using a for loop
     std::vector<std::vector<double> > mutList(mutCount, zeros);
     for (int i = 0; i < mutCount; ++i) {
-        std::mt19937 gen(randomnessSource());
-        mutList[i][0] = lbMutMaker(gen);
-        mutList[i][1] = bpMutMaker(gen);
+        std::mt19937 lbGen(lbRandomnessSource());
+        mutList[i][0] = lbMutMaker(lbGen);
+        std::mt19937 bpGen(bpRandomnessSource());
+        mutList[i][1] = bpMutMaker(bpGen);
     }
     
     return mutList;
@@ -374,13 +374,16 @@ Individual pickAndMateParents(std::vector<Individual> &population, double totalF
     // Genotype inheritance
     for(int i = 0; i < baby.lbMutations.size(); i++) {
         val = rand(); // using val = randominteger(0, RAND_MAX) causes a huge performance hit
-        if(val % mutRate == 0) {
+        // double val = randomdouble(0, 1);
+        // if (val < 1 / (double) mutRate) {
+        if (val % mutRate == 0) {
             baby.lbMutations[i] = mutList[i][0];
             baby.bpMutations[i] = mutList[i][1];
-        } else if(val %2 == 0){
+        // } else if (val < 0.5) {
+        } else if (val %2 == 0) {
             baby.lbMutations[i] = population[parentAidx].lbMutations[i];
             baby.bpMutations[i] = population[parentAidx].bpMutations[i];
-        } else{
+        } else {
             baby.lbMutations[i] = population[parentBidx].lbMutations[i];
             baby.bpMutations[i] = population[parentBidx].bpMutations[i];
         }
@@ -523,7 +526,7 @@ void evolvePop(vector<Individual> &population, double target, double selStrength
             counter++;
         }
     }
-    *uniqueParents = std::set<double>( parentIndices.begin(), parentIndices.end() ).size();
+    *uniqueParents = std::set<int>( parentIndices.begin(), parentIndices.end() ).size();
     // Check for unassigned shelters
     std::vector<int> shelteredIndividuals;
     for(int l = 0; l < popSize; l++) {
@@ -537,7 +540,7 @@ void evolvePop(vector<Individual> &population, double target, double selStrength
     if (showShelterStats) {
         cout << "   Assigned shelters: " << shelteredIndividuals.size() << endl;
         cout << "   Unassigned shelters: " << availableShelters << endl;
-        cout << "   Unique parents: " << std::set<double>( parentIndices.begin(), parentIndices.end() ).size() << endl;
+        cout << "   Unique parents: " << std::set<int>( parentIndices.begin(), parentIndices.end() ).size() << endl;
     }
     
     // Assign remaining shelters at random

--- a/simulation.cpp
+++ b/simulation.cpp
@@ -45,7 +45,7 @@ int main(int argc, char** argv)
     // Standard deviation of log body size
     const double bodySizeStDev = 0.01;
     // Standard deviation of bequeathal probability
-    const double beqProbStDev = 0.025;
+    const double beqProbStDev = 0.005;
     
     po::options_description desc("Simulate trait evolution under wealth inheritance");
     desc.add_options()
@@ -226,7 +226,7 @@ int main(int argc, char** argv)
                 if (count % outputFrequency == 0) {
 		   
                     evolvePop(Pop, target_lb, selection_strength, min_lb, max_lb, popSize, mutList, nShelters, calamityFrequency, calamityStrength, true, &uniqueParents);
-		    genFile << uniqueParents << "\n";
+                    genFile << uniqueParents << endl;
                     cout << "generation: " << count;
                     cout << "   Avg body size: " << pow(10, (getTraitMean(Pop, "bodySize")));
                     cout << "   Avg bequeathal prob: " << getTraitMean(Pop, "beqProb");
@@ -427,8 +427,8 @@ Individual pickAndMateParents(std::vector<Individual> &population, double totalF
             }
         }
     }
-*parentA = parentAidx;
-*parentB = parentBidx;
+    *parentA = parentAidx;
+    *parentB = parentBidx;
     return baby;
 }
 
@@ -505,7 +505,7 @@ void evolvePop(vector<Individual> &population, double target, double selStrength
     Individual ind = reproductivePop[0];
     std::vector<Individual> newPop(popSize, ind);
     while(counter < popSize) {
-	int parentA, parentB;
+        int parentA, parentB;
         // Pick parents and make a baby
         Individual baby = pickAndMateParents(reproductivePop, totalFitness, target, fitnessArr, mutList, &parentA, &parentB);
 
@@ -517,7 +517,7 @@ void evolvePop(vector<Individual> &population, double target, double selStrength
             }
         } else {
             newPop[counter] = baby;
-		parentIndices.push_back(parentA);
+            parentIndices.push_back(parentA);
      		parentIndices.push_back(parentB);
             // Add baby to newPop
             counter++;
@@ -537,7 +537,7 @@ void evolvePop(vector<Individual> &population, double target, double selStrength
     if (showShelterStats) {
         cout << "   Assigned shelters: " << shelteredIndividuals.size() << endl;
         cout << "   Unassigned shelters: " << availableShelters << endl;
-	cout << "   Unique parents: " << std::set<double>( parentIndices.begin(), parentIndices.end() ).size() << endl;
+        cout << "   Unique parents: " << std::set<double>( parentIndices.begin(), parentIndices.end() ).size() << endl;
     }
     
     // Assign remaining shelters at random

--- a/simulation.cpp
+++ b/simulation.cpp
@@ -284,9 +284,19 @@ int main(int argc, char** argv)
         // Print endpoint data
         std::vector<double> fitnessArr(popSize, 0.0);
         outputFile << exp(getTraitMean(Pop, "bodySize")) << "\t" << getTraitVar(Pop, "bodySize") << "\t" << getTraitMean(Pop, "beqProb") << "\t" << getTraitVar(Pop, "beqProb") << "\t" << getTotalFitness(Pop, target_lb, selection_strength, fitnessArr) / popSize << "\t" << count << endl;
+        
+        // Print a waring if the simulation has timed out without reaching the target
+        if (!finished && count == gen_limit) {
+            cout << " " << endl;
+            cout << "Warning: the simulation did not reach the stopping criterion!" << endl;
+            cout << "Try increasing the number of generations by setting the 'gen_limit' flag to a value > " << gen_limit << "." << endl;
+            cout << " " << endl;
+            outputFile << "Warning: the simulation did not reach the stopping criterion!" << endl;
+        }
 
-        // Generation files closing
+        // Generation and endpoint files closing
         genFile.close();
+        outputFile.close();
         
     }
     return 0;


### PR DESCRIPTION
Merging all recent changes into `main`. These include: (1) using the natural log rather than log10 of body size; (2) adding the ability to evolve only one trait at a time; (3) ensuring that the generation files start with the last burnin generation rather than the first post-burnin generation; (4) changing the default values of several parameters; and (5) allowing the user to specify several options that were formerly hardcoded into the simulation (trait mutation strength, output frequency).